### PR TITLE
Refactor planner agent and add simple RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# LLM_GIS
+# Tutoring Assistant
+
+This project contains a small command-line tutoring assistant. It keeps a
+JSON profile per user and can run in **learn**, **review** or **test** mode.
+
+```
+python main.py
+```
+
+Set the environment variable `OPENAI_API_KEY` if you want to query OpenAI.
+Without it, stub responses will be returned.
+
+The planner is implemented as an agent that queries the domain expert LLM to
+create learning plans and drive teaching loops. The domain expert includes a
+minimal retrieval step that pulls text snippets from the `docs/` directory and
+injects them into prompts (a lightweight RAG approach). If no API key is
+provided or parsing fails, defaults from `topics.json` are used.

--- a/docs/algebra.txt
+++ b/docs/algebra.txt
@@ -1,0 +1,3 @@
+Algebra Basics: Variables represent numbers. Operations follow standard arithmetic.
+Quadratic Equations: Have the form ax^2 + bx + c = 0 and can be solved with the quadratic formula.
+

--- a/domain_expert.py
+++ b/domain_expert.py
@@ -1,0 +1,74 @@
+"""OpenAI wrapper with a tiny RAG helper."""
+import os
+from pathlib import Path
+
+try:  # pragma: no cover - library might not be installed in tests
+    import openai
+except ImportError:  # pragma: no cover - fall back to stubs
+    openai = None
+
+MODEL = os.environ.get('OPENAI_MODEL', 'gpt-3.5-turbo')
+DOCUMENTS_PATH = Path('docs')
+
+
+def _retrieve_context(topic: str) -> str:
+    """Very small retrieval helper that concatenates text files containing the topic."""
+    context_parts = []
+    if DOCUMENTS_PATH.exists():
+        for path in DOCUMENTS_PATH.glob('*.txt'):
+            text = path.read_text()
+            if topic.lower() in text.lower():
+                context_parts.append(text.strip())
+    return '\n'.join(context_parts)
+
+
+def query_domain_expert(prompt: str, context: str = "") -> str:
+    if context:
+        prompt = f"Use the following context to answer:\n{context}\n\n{prompt}"
+    if openai is None:
+        return f"[Stubbed response for prompt: {prompt[:40]}...]"
+    api_key = os.environ.get('OPENAI_API_KEY')
+    if not api_key:
+        raise RuntimeError('OPENAI_API_KEY not set')
+    openai.api_key = api_key
+    resp = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=[{'role': 'user', 'content': prompt}],
+    )
+    return resp.choices[0].message['content']
+
+
+def explain_concept(topic: str) -> str:
+    prompt = f"Explain the concept of {topic} in simple terms."
+    context = _retrieve_context(topic)
+    return query_domain_expert(prompt, context)
+
+
+def generate_example(topic: str) -> str:
+    prompt = f"Provide a worked example for {topic}."
+    context = _retrieve_context(topic)
+    return query_domain_expert(prompt, context)
+
+
+def generate_question(topic: str) -> str:
+    prompt = f"Create a short question on {topic}."
+    context = _retrieve_context(topic)
+    return query_domain_expert(prompt, context)
+
+
+def check_answer(question: str, answer: str):
+    prompt = (
+        f"Question: {question}\nUser answer: {answer}\n"
+        "Determine if the answer is correct and explain."
+    )
+    context = _retrieve_context(question)
+    feedback = query_domain_expert(prompt, context)
+    correct = 'correct' in feedback.lower()
+    return correct, feedback
+
+
+def generate_summary(topic: str) -> str:
+    prompt = f"Give a short summary of {topic}."
+    context = _retrieve_context(topic)
+    return query_domain_expert(prompt, context)
+

--- a/main.py
+++ b/main.py
@@ -1,96 +1,59 @@
-import PyPDF2
-import camelot
-import re
-import io
-import numpy as np
-from sentence_transformers import SentenceTransformer
+"""CLI entry point for tutoring assistant."""
+from memory import load_user, save_user, get_weak_areas
+from planner import PlannerAgent
+from utils import choose_option
+from domain_expert import generate_question, check_answer
 
-# 1) Extract text from PDF using PyPDF2
-def extract_text_from_pdf(pdf_path):
-    text = ""
-    with open(pdf_path, 'rb') as file:
-        pdf_reader = PyPDF2.PdfReader(file)
-        for page_num in range(len(pdf_reader.pages)):
-            page = pdf_reader.pages[page_num]
-            page_text = page.extract_text()
-            if page_text:
-                text += f"\n--- Page {page_num+1} ---\n{page_text}\n"
-    return text
 
-# 2) Extract tables from PDF using Camelot
-def extract_tables_from_pdf(pdf_path):
-    tables = camelot.read_pdf(pdf_path, pages='all', flavor='lattice')
-    dfs = []
-    for t in tables:
-        dfs.append(t.df)
-    return dfs
+def review_mode(agent: PlannerAgent):
+    weak_topics = get_weak_areas(agent.username)
+    if not weak_topics:
+        print("No weak areas to review.")
+        return
+    for topic in weak_topics:
+        question = generate_question(topic)
+        answer = input(question + "\nYour answer: ")
+        _, feedback = check_answer(question, answer)
+        print(feedback)
 
-# Convert a DataFrame to CSV text
-def dataframe_to_text(df):
-    import io
-    with io.StringIO() as buffer:
-        df.to_csv(buffer, index=False)
-        return buffer.getvalue().strip()
 
-def tables_to_text(dfs):
-    table_texts = []
-    for idx, df in enumerate(dfs):
-        csv_str = dataframe_to_text(df)
-        labeled_str = f"--- Table {idx+1} ---\n{csv_str}"
-        table_texts.append(labeled_str)
-    return table_texts
+def learn_mode(agent: PlannerAgent):
+    topic = input("Enter topic to learn: ")
+    agent.run_learning_loop(topic)
 
-# 3) Chunk text into smaller segments
-def chunk_text(text, max_chars=500):
-    sentences = re.split(r'(?<=[.?!])\s+', text)
-    chunks = []
-    current_chunk = ""
-    
-    for sentence in sentences:
-        if len(current_chunk) + len(sentence) < max_chars:
-            current_chunk += sentence + " "
-        else:
-            chunks.append(current_chunk.strip())
-            current_chunk = sentence + " "
-    if current_chunk:
-        chunks.append(current_chunk.strip())
-    return chunks
 
-# 4) The main workflow
-pdf_path = "/teamspace/studios/this_studio/Tricor label.pdf"  # <-- Replace with your file
-pdf_text = extract_text_from_pdf(pdf_path)
+def test_mode(agent: PlannerAgent):
+    topic = input("Topic to test: ")
+    num_q = 3
+    correct = 0
+    for _ in range(num_q):
+        q = generate_question(topic)
+        ans = input(q + "\nYour answer: ")
+        ok, feedback = check_answer(q, ans)
+        if ok:
+            correct += 1
+        print(feedback)
+    print(f"You scored {correct}/{num_q}")
 
-table_dfs = extract_tables_from_pdf(pdf_path)
-table_texts = tables_to_text(table_dfs)
 
-# Combine plain text + table CSV text
-all_text = pdf_text + "\n".join(table_texts)
+def main():
+    username = input("Username: ")
+    agent = PlannerAgent(username)
+    profile = load_user(username)
+    mode = agent.suggest_mode()
+    choice = choose_option(
+        f"Select mode (suggested: {mode}): ",
+        ["review", "learn", "test"]
+    )
+    if choice == "review":
+        review_mode(agent)
+    elif choice == "learn":
+        learn_mode(agent)
+    else:
+        test_mode(agent)
+    save_user(username, load_user(username))
 
-# Split into chunks
-chunks = chunk_text(all_text, max_chars=500)
 
-# Embed with sentence-transformers
-model = SentenceTransformer('all-MiniLM-L6-v2')
-chunk_embeddings = model.encode(chunks)
-chunk_embeddings = np.array(chunk_embeddings)
+if __name__ == "__main__":
+    main()
 
-# Store (embedding, text_chunk) in a list
-indexed_chunks = [(chunk_embeddings[i], chunks[i]) for i in range(len(chunks))]
-
-# Retrieval function: use embedding similarity to recover chunk text
-def retrieve_text_from_embedding(target_embedding, indexed_chunks, top_k=1):
-    similarities = []
-    for emb, txt in indexed_chunks:
-        cos_sim = np.dot(emb, target_embedding) / (np.linalg.norm(emb) * np.linalg.norm(target_embedding))
-        similarities.append((cos_sim, txt))
-    similarities.sort(key=lambda x: x[0], reverse=True)
-    return [chunk_text for _, chunk_text in similarities[:top_k]]
-
-# Example usage: try retrieving chunk #9 from its own embedding
-test_embedding = chunk_embeddings[9]
-reconstructed = retrieve_text_from_embedding(test_embedding, indexed_chunks, top_k=1)
-
-print("Original chunk:")
-print(chunks[9])
-print("\nReconstructed chunk:")
-print(reconstructed[0],reconstructed[1])

--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+DATA_FILE = Path('users.json')
+
+
+def load_user(username: str) -> dict:
+    data = {}
+    if DATA_FILE.exists():
+        with DATA_FILE.open('r') as f:
+            data = json.load(f)
+    return data.get(username, {
+        'weak_areas': [],
+        'topic_mastery': {},
+        'history': [],
+        'learning_plan': {}
+    })
+
+
+def save_user(username: str, profile: dict) -> None:
+    if DATA_FILE.exists():
+        with DATA_FILE.open('r') as f:
+            data = json.load(f)
+    else:
+        data = {}
+    data[username] = profile
+    with DATA_FILE.open('w') as f:
+        json.dump(data, f, indent=2)
+
+
+def update_progress(username: str, topic: str, mastery: str) -> None:
+    profile = load_user(username)
+    profile['topic_mastery'][topic] = mastery
+    if topic in profile.get('weak_areas', []) and mastery != 'weak':
+        profile['weak_areas'].remove(topic)
+    save_user(username, profile)
+
+
+def get_weak_areas(username: str):
+    profile = load_user(username)
+    return profile.get('weak_areas', [])

--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,107 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+from memory import load_user, save_user
+from domain_expert import (
+    explain_concept,
+    generate_example,
+    generate_question,
+    check_answer,
+    generate_summary,
+    query_domain_expert,
+)
+
+TOPICS_FILE = Path('topics.json')
+
+
+def load_topics() -> dict:
+    if TOPICS_FILE.exists():
+        with TOPICS_FILE.open('r') as f:
+            return json.load(f)
+    return {}
+
+
+class PlannerAgent:
+    """Agent that builds plans and drives learning loops."""
+
+    def __init__(self, username: str):
+        self.username = username
+
+    # ---- Memory helpers ----
+    @property
+    def profile(self) -> dict:
+        return load_user(self.username)
+
+    def save_profile(self, profile: dict) -> None:
+        save_user(self.username, profile)
+
+    # ---- Agent functions ----
+    def suggest_mode(self) -> str:
+        profile = self.profile
+        if profile.get('weak_areas'):
+            return 'review'
+        return 'learn'
+
+    def build_learning_plan(self, topic: str) -> Dict:
+        topics = load_topics()
+
+        prereqs: List[str] = []
+        difficulty = "beginner"
+        est_time = 20
+        num_q = 5
+
+        for _parent, children in topics.items():
+            if topic in children:
+                info = children[topic]
+                prereqs = info.get("prerequisites", [])
+                difficulty = info.get("difficulty", "beginner")
+                est_time = info.get("estimated_time", 20)
+                num_q = info.get("num_questions", 5)
+                break
+
+        prompt = (
+            "Create a JSON learning plan for the topic '{t}'. Include fields: "
+            "topic, prerequisites, estimated_time, num_questions, difficulty. "
+            "Use prerequisites {p}. Difficulty hint: {d}.".format(
+                t=topic, p=prereqs or [], d=difficulty
+            )
+        )
+
+        plan = {
+            "topic": topic,
+            "prerequisites": prereqs,
+            "estimated_time": est_time,
+            "num_questions": num_q,
+            "difficulty": difficulty,
+        }
+
+        try:
+            response = query_domain_expert(prompt)
+            plan.update(json.loads(response))
+        except Exception:
+            pass  # fall back to default plan
+
+        return plan
+
+    def run_learning_loop(self, topic: str) -> None:
+        profile = self.profile
+        plan = self.build_learning_plan(topic)
+        # Ensure prerequisites mastered
+        for prereq in plan['prerequisites']:
+            if profile['topic_mastery'].get(prereq) != 'mastered':
+                self.run_learning_loop(prereq)
+                profile = self.profile
+        # Teach concept
+        print(explain_concept(topic))
+        print(generate_example(topic))
+        question = generate_question(topic)
+        user_answer = input(question + "\nYour answer: ")
+        correct, feedback = check_answer(question, user_answer)
+        print(feedback)
+        print(generate_summary(topic))
+        profile['topic_mastery'][topic] = 'mastered' if correct else 'intermediate'
+        self.save_profile(profile)
+
+
+

--- a/topics.json
+++ b/topics.json
@@ -1,0 +1,14 @@
+{
+  "Algebra": {
+    "Algebra Basics": {
+      "prerequisites": [],
+      "difficulty": "beginner"
+    },
+    "Quadratic Equations": {
+      "prerequisites": ["Algebra Basics"],
+      "difficulty": "intermediate",
+      "estimated_time": 20,
+      "num_questions": 5
+    }
+  }
+}

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,12 @@
+from typing import Iterable
+
+
+def choose_option(prompt: str, options: Iterable[str]) -> str:
+    opts = list(options)
+    for idx, opt in enumerate(opts, 1):
+        print(f"{idx}. {opt}")
+    while True:
+        choice = input(prompt)
+        if choice.isdigit() and 1 <= int(choice) <= len(opts):
+            return opts[int(choice) - 1]
+        print("Invalid selection")


### PR DESCRIPTION
## Summary
- refactor planner module into `PlannerAgent`
- add small retrieval step to domain expert (RAG)
- integrate agent with CLI
- include sample docs for retrieval

## Testing
- `python -m py_compile main.py memory.py planner.py domain_expert.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68408d191498832ab0726442bc5e6eaa